### PR TITLE
Update bootstrap.js to fix browserify2:dev task

### DIFF
--- a/client/js/node_modules/bootstrap.js
+++ b/client/js/node_modules/bootstrap.js
@@ -5,4 +5,4 @@
 require('jquery');
 
 require('./bower_components/bootstrap/dist/js/bootstrap');
-require('./bower_components/bootstrap/assets/js/holder');
+require('./bower_components/bootstrap/docs-assets/js/holder');


### PR DESCRIPTION
To fix error in task:

```
Running "browserify2:dev" (browserify2) task
>> Error: module "./bower_components/bootstrap/assets/js/holder" not found from "/path/to/yeoman-ultimate/client/js/node_modules/bootstrap.js"
File written to: .tmp/js/main.js
```
