### PR TITLE
Update bower.json to avoid error on "bower install" command

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
     "font-awesome": "~3.2.1",
     "jquery": "~2.0.3",
     "json3": "~3.2.5",
-    "lesshat": "~1.1.2",
+    "lesshat": "https://github.com/csshat/lesshat.git#~1.1.2",
     "modernizr": "~2.6.2",
     "restangular": "~1.1.3",
     "socket.io-client": "~0.9.16",


### PR DESCRIPTION
While we wait for the bower team to rename the lesshat component in their database (see requests at https://github.com/bower/bower/issues/120#issuecomment-27586470 and https://github.com/bower/bower/issues/953), this change makes an explicit reference to the lesshat repo.
