### PR TITLE
Add IP address logging to Winston loggers.

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -72,6 +72,8 @@ app.attachMiddlewares = function () {
 
   // Custom
   app.servers.express.getServer().use(function (req, res, next) {
+    req._routeWhitelists.req = ['ip'];
+
     if (process.env.NODE_ENV === 'development') {
       res.locals.livereload = app.project.server.livereload;
     }


### PR DESCRIPTION
There may be a better place (and method) for this, but this successfully adds IP address logging. Note that use of a proxy [may also require](http://stackoverflow.com/a/14631683) `app.enable('trust proxy')` (or else you will get the proxy IP address).
